### PR TITLE
Set visibility hidden on split

### DIFF
--- a/_dist/index.esm.js
+++ b/_dist/index.esm.js
@@ -4282,17 +4282,23 @@ var require_split = __commonJS({
         if (!previous && !state) {
           meta[panel] = {
             [panel]: this[panel].style[property],
+            [panel + "visibility"]: this[panel].style.visibility,
             [opposite]: this[opposite].style[property],
+            [opposite + "visibility"]: this[opposite].style.visibility,
             handle: this.handle.style.display
           };
           this[panel].style[property] = 0;
+          this[panel].style.visibility = "hidden";
           this[opposite].style[property] = "100%";
+          this[opposite].style.visibility = "inherit";
           this.handle.style.display = "none";
           return;
         }
         if (previous) {
           this[panel].style[property] = previous[panel];
+          this[panel].style.visibility = previous[panel + "visibility"];
           this[opposite].style[property] = previous[opposite];
+          this[opposite].style.visibility = previous[opposite + "visibility"];
           this.handle.style.display = previous.handle;
           delete meta[panel];
         }

--- a/_dist/index.js
+++ b/_dist/index.js
@@ -4275,17 +4275,23 @@ var require_split = __commonJS({
         if (!previous && !state) {
           meta[panel] = {
             [panel]: this[panel].style[property],
+            [panel + "visibility"]: this[panel].style.visibility,
             [opposite]: this[opposite].style[property],
+            [opposite + "visibility"]: this[opposite].style.visibility,
             handle: this.handle.style.display
           };
           this[panel].style[property] = 0;
+          this[panel].style.visibility = "hidden";
           this[opposite].style[property] = "100%";
+          this[opposite].style.visibility = "inherit";
           this.handle.style.display = "none";
           return;
         }
         if (previous) {
           this[panel].style[property] = previous[panel];
+          this[panel].style.visibility = previous[panel + "visibility"];
           this[opposite].style[property] = previous[opposite];
+          this[opposite].style.visibility = previous[opposite + "visibility"];
           this.handle.style.display = previous.handle;
           delete meta[panel];
         }

--- a/input/test.js
+++ b/input/test.js
@@ -356,7 +356,7 @@ tape('input wrapper component interactions', async t => {
     const input2 = comp.querySelector('input')
     t.equal(input2.value, 'someText')
     resolve()
-  }, 20))
+  }, 50))
 
   await p
 })

--- a/split/index.js
+++ b/split/index.js
@@ -202,7 +202,9 @@ class TonicSplit extends Tonic {
       //
       meta[panel] = {
         [panel]: this[panel].style[property],
+        [panel + 'visibility']: this[panel].style.visibility,
         [opposite]: this[opposite].style[property],
+        [opposite + 'visibility']: this[opposite].style.visibility,
         handle: this.handle.style.display
       }
 
@@ -211,7 +213,9 @@ class TonicSplit extends Tonic {
       // and set the opposite panel to fill the splitter
       //
       this[panel].style[property] = 0
+      this[panel].style.visibility = 'hidden'
       this[opposite].style[property] = '100%'
+      this[opposite].style.visibility = 'inherit'
       this.handle.style.display = 'none'
       return
     }
@@ -222,7 +226,9 @@ class TonicSplit extends Tonic {
     //
     if (previous) {
       this[panel].style[property] = previous[panel]
+      this[panel].style.visibility = previous[panel + 'visibility']
       this[opposite].style[property] = previous[opposite]
+      this[opposite].style.visibility = previous[opposite + 'visibility']
       this.handle.style.display = previous.handle
       delete meta[panel]
     }


### PR DESCRIPTION
This fixes an issue with tabbing behavior, previously content
in a splitter that was height 0 could be tabbed into which
would scroll the whole UI and cause confusion.