### PR TITLE
Correctly parse date strings

### DIFF
--- a/relative-time/index.js
+++ b/relative-time/index.js
@@ -451,7 +451,10 @@ export class TonicRelativeTime extends Tonic {
     const locale = this.props.locale || localeFromElement(this)
 
     if (typeof date === 'string') {
-      date = this.props.date = new Date(+this.props.date)
+      date = this.props.date =
+        /^\d+$/.test(this.props.date)
+          ? new Date(+this.props.date)
+          : new Date(this.props.date)
     }
 
     if (typeof date === 'number') {


### PR DESCRIPTION
This fixes a failing test by parsing date strings when they are passed in. 